### PR TITLE
Switch manage_etc_hosts from True to localhost

### DIFF
--- a/elements/base/install.d/10-cloud-init
+++ b/elements/base/install.d/10-cloud-init
@@ -5,5 +5,5 @@ set -eu
 set -o pipefail
 
 dd of=/etc/cloud/cloud.cfg.d/10_etc_hosts.cfg << EOF
-manage_etc_hosts: True
+manage_etc_hosts: localhost
 EOF


### PR DESCRIPTION
When set to true, this cloud-init setting overwrites the /etc/hosts
file at reboot from a template. We want cloud-init to add in the hosts
file a mapping for the local fqdn, but not to overwrite it, so we switched
to 'localhost' [1]
1. http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/doc/examples/cloud-config.txt#L470
