### PR TITLE
Fix for RHEL6

### DIFF
--- a/elements/rhel-common/README.md
+++ b/elements/rhel-common/README.md
@@ -26,6 +26,7 @@ IMPORTANT NOTE:
 The 00-rhsm script is specific to RHEL6.  If you use the REG_ variables to
 use with RHEL7, you do not need to set any DIB_RHSM variables.  The scripts
 named with "rhel-registration" have not been developed or tested for RHEL6.
+For information on building RHEL6 images, please see the rhel element README.
 
 Environment Variables For Image Creation
 ----------------------------------------

--- a/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
+++ b/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
@@ -23,7 +23,7 @@ REG_METHOD="$(os-apply-config --key rh_registration.method --type raw --key-defa
 opts=
 attach_opts=
 repos="repos --enable rhel-7-server-rpms"
-satellite_repo="rhel-7-server-rh-common-beta-rpms"
+satellite_repo="rhel-7-server-rh-common-rpms"
 if [ -n "${REG_AUTO_ATTACH:-}" ]; then
     opts="$opts --auto-attach"
 
@@ -115,7 +115,6 @@ case "${REG_METHOD:-}" in
         subscription-manager $repos
         yum install -y katello-agent || true # needed for errata reporting to satellite6
         katello-package-upload
-        # beta-rpms repo only needed to support the katello-ca rpm above.
         subscription-manager repos --disable ${satellite_repo}
         ;;
     disable)

--- a/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
+++ b/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
@@ -2,6 +2,12 @@
 set -eu
 set -o pipefail
 
+OK=/mnt/state/var/lib/rhsm/rhsm.ok
+
+if [ -e $OK ] ; then
+    exit 0
+fi
+
 REG_ACTIVATION_KEY="$(os-apply-config --key rh_registration.activation_key --type raw --key-default '')"
 REG_AUTO_ATTACH="$(os-apply-config --key rh_registration.auto_attach --type raw --key-default 'true')"
 REG_BASE_URL="$(os-apply-config --key rh_registration.base_url --type raw --key-default '')"
@@ -124,3 +130,6 @@ case "${REG_METHOD:-}" in
         echo "WARNING: only 'portal', 'satellite', and 'disable' are valid values for REG_METHOD."
         exit 0
 esac
+
+mkdir -p $(dirname $OK)
+touch $OK

--- a/elements/rhel-common/pre-install.d/00-rhel-registration
+++ b/elements/rhel-common/pre-install.d/00-rhel-registration
@@ -103,5 +103,5 @@ case "${REG_METHOD:-}" in
         ;;
     *)
         echo "WARNING: only 'portal', 'satellite', and 'disable' are valid values for REG_METHOD."
-        exit 1
+        exit 0
 esac

--- a/elements/rhel-common/pre-install.d/00-rhel-registration
+++ b/elements/rhel-common/pre-install.d/00-rhel-registration
@@ -5,7 +5,7 @@ set -o pipefail
 opts=
 attach_opts=
 repos="repos --enable rhel-7-server-rpms"
-satellite_repo="rhel-7-server-rh-common-beta-rpms"
+satellite_repo="rhel-7-server-rh-common-rpms"
 
 if [ -n "${REG_AUTO_ATTACH:-}" ]; then
     opts="$opts --auto-attach"
@@ -94,8 +94,7 @@ case "${REG_METHOD:-}" in
         rpm -Uvh "$REG_SAT_URL/pub/katello-ca-consumer-latest.noarch.rpm" || true
         subscription-manager register $opts
         subscription-manager $repos
-        # beta-rpms repo only needed to support the katello-ca rpm above.
-        subscription-manager repos --disable rhel-7-server-rh-common-beta-rpms
+        subscription-manager repos --disable ${satellite_repo}
         ;;
     disable)
         echo "Disabling RHEL registration"


### PR DESCRIPTION
The correct workflow for building RHEL6 images includes not using
the rhel-registration scripts in this element, but rather the 00-rhsm
script.  This patch updates the return value from 1 to 0 for the case
when the REG_METHOD is left unset.  This will allow the RHEL6 images
to build without needing to set REG_METHOD. This patch also improves
the note about RHEL6 image building.

This patch is the result of the discussion in the comments of [1].

[1] Iff7b9fc30d5a36231598a977a9edcd55229766c5

Change-Id: I2f35b8d7d8749d44d88f06e9e2c3116ff93b88fe
Closes-Bug: 1404364
