### PR TITLE
Fix Satellite Repo

### DIFF
--- a/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
+++ b/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
@@ -23,7 +23,7 @@ REG_METHOD="$(os-apply-config --key rh_registration.method --type raw --key-defa
 opts=
 attach_opts=
 repos="repos --enable rhel-7-server-rpms"
-satellite_repo="rhel-7-server-rh-common-beta-rpms"
+satellite_repo="rhel-7-server-rh-common-rpms"
 if [ -n "${REG_AUTO_ATTACH:-}" ]; then
     opts="$opts --auto-attach"
 
@@ -115,7 +115,6 @@ case "${REG_METHOD:-}" in
         subscription-manager $repos
         yum install -y katello-agent || true # needed for errata reporting to satellite6
         katello-package-upload
-        # beta-rpms repo only needed to support the katello-ca rpm above.
         subscription-manager repos --disable ${satellite_repo}
         ;;
     disable)

--- a/elements/rhel-common/pre-install.d/00-rhel-registration
+++ b/elements/rhel-common/pre-install.d/00-rhel-registration
@@ -5,7 +5,7 @@ set -o pipefail
 opts=
 attach_opts=
 repos="repos --enable rhel-7-server-rpms"
-satellite_repo="rhel-7-server-rh-common-beta-rpms"
+satellite_repo="rhel-7-server-rh-common-rpms"
 
 if [ -n "${REG_AUTO_ATTACH:-}" ]; then
     opts="$opts --auto-attach"
@@ -94,8 +94,7 @@ case "${REG_METHOD:-}" in
         rpm -Uvh "$REG_SAT_URL/pub/katello-ca-consumer-latest.noarch.rpm" || true
         subscription-manager register $opts
         subscription-manager $repos
-        # beta-rpms repo only needed to support the katello-ca rpm above.
-        subscription-manager repos --disable rhel-7-server-rh-common-beta-rpms
+        subscription-manager repos --disable ${satellite_repo}
         ;;
     disable)
         echo "Disabling RHEL registration"


### PR DESCRIPTION
Previous to the Sattelite 6 release, the katello-agent and it's
dependencies needed the rhel-7-server-rh-common-beta-rpms repo
enabled.  Since the the release of Satellite 6, the "beta" can
be safely dropped.  This fixes an error where registration to a
satellite instance fails due to a 404 for the beta repo.

Change-Id: Ia9879498c7db0c912bb58ea084d448b8b3915569

Signed-off-by: Ryan Brady rbrady@redhat.com
