### PR TITLE
Run Registration Once

### DIFF
--- a/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
+++ b/elements/rhel-common/os-refresh-config/pre-configure.d/06-rhel-registration
@@ -2,6 +2,12 @@
 set -eu
 set -o pipefail
 
+OK=/mnt/state/var/lib/rhsm/rhsm.ok
+
+if [ -e $OK ] ; then
+    exit 0
+fi
+
 REG_ACTIVATION_KEY="$(os-apply-config --key rh_registration.activation_key --type raw --key-default '')"
 REG_AUTO_ATTACH="$(os-apply-config --key rh_registration.auto_attach --type raw --key-default 'true')"
 REG_BASE_URL="$(os-apply-config --key rh_registration.base_url --type raw --key-default '')"
@@ -125,3 +131,6 @@ case "${REG_METHOD:-}" in
         echo "WARNING: only 'portal', 'satellite', and 'disable' are valid values for REG_METHOD."
         exit 0
 esac
+
+mkdir -p $(dirname $OK)
+touch $OK


### PR DESCRIPTION
The rhel-common element has a script that uses subscription-manager
to register an instance of RHEL with the customer portal or Satellite.
If os-refresh-config runs this script more than once,
subscription-manager returns a non-zero value causing os-refresh-config
to fail.  Adding --force to the subscription-manager calls doesn't
properly unregister the image from Satellite and the result is multiple
content host registrations. This patch changes the registration to only
run once.

Change-Id: If372e7f59bbdc77e2b233024c1342f005004f2e5
