### PR TITLE
Open MKFS_OPTS for extension in disk-image-create

### DIFF
--- a/bin/disk-image-create
+++ b/bin/disk-image-create
@@ -58,6 +58,8 @@ function show_options () {
     echo "       Making this value unnecessarily large will consume extra disk space "
     echo "       on the root partition with extra file system inodes."
     echo "    --min-tmpfs size -- minimum size in GB needed in tmpfs to build the image"
+    echo "    --mkfs-options -- option flags to be passed directly to mkfs."
+    echo "       Options should be passed as a single string value."
     echo "    --no-tmpfs -- do not use tmpfs to speed image build"
     echo "    --offline -- do not update cached resources"
     if [ "$IS_RAMDISK" == "0" ]; then
@@ -83,7 +85,8 @@ function show_options () {
 
 INSTALL_PACKAGES=""
 COMPRESS_IMAGE="true"
-TEMP=`getopt -o a:ho:xucnp: -l no-tmpfs,offline,help,min-tmpfs:,image-size:,image-cache:,max-online-resize: -n $SCRIPTNAME -- "$@"`
+MKFS_OPTS=""
+TEMP=`getopt -o a:ho:xucnp: -l no-tmpfs,offline,help,min-tmpfs:,image-size:,image-cache:,max-online-resize:,mkfs-options: -n $SCRIPTNAME -- "$@"`
 if [ $? -ne 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
 # Note the quotes around `$TEMP': they are essential!
@@ -103,6 +106,7 @@ while true ; do
         --image-cache) export DIB_IMAGE_CACHE=$2; shift 2;;
         --max-online-resize) export MAX_ONLINE_RESIZE=$2; shift 2;;
         --min-tmpfs) export DIB_MIN_TMPFS=$2; shift 2;;
+        --mkfs-options) MKFS_OPTS=$2; shift 2;;
         --no-tmpfs) shift; export DIB_NO_TMPFS=1;;
         --offline) shift; export DIB_OFFLINE=1;;
         --) shift ; break ;;
@@ -145,8 +149,6 @@ prepare_first_boot
 unmount_image
 mv $TMP_BUILD_DIR/mnt $TMP_BUILD_DIR/built
 
-MKFS_OPTS=""
-
 if [ -n "$DIB_IMAGE_SIZE" ]; then
   truncate -s${DIB_IMAGE_SIZE}G $TMP_IMAGE_PATH
 else
@@ -161,12 +163,12 @@ else
     # Very conservative to handle images being resized a lot
     # Without -J option specified, default journal size will be set to 32M
     # and online resize will be failed with error of needs too many credits.
-    MKFS_OPTS="-i 4096 -J size=64"
+    MKFS_OPTS="-i 4096 -J size=64 $MKFS_OPTS"
   fi
 fi
 
 if [ -n "$MAX_ONLINE_RESIZE" ]; then
-    MKFS_OPTS="$MKFS_OPTS -E resize=$MAX_ONLINE_RESIZE"
+    MKFS_OPTS="-E resize=$MAX_ONLINE_RESIZE $MKFS_OPTS"
 fi
 
 LOOPDEV=$(sudo losetup --show -f $TMP_IMAGE_PATH)


### PR DESCRIPTION
At present, MKFS_OPTS is closed for modification. The ability
to extend the set of MKFS_OPTS adds a great deal of power for
knowledgeable end-users. (And in some specific circumstances,
it is vital to success, as in the case of building RHEL/CentOS
6 images from RHEL/CentOS 7 hosts, in which case -O ^64bit is
required in order for the image to boot.)

Presently upstream at https://review.openstack.org/#/c/165149;
I am adding it here to facilitate the packaging of Sahara image
element creation for Icehouse (on RHEL/CentOS 7->RHEL/CentOS 6)
at the earliest opportunity. Thanks.
